### PR TITLE
Fix missing nav links on homepage

### DIFF
--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -12,8 +12,10 @@ function updateNavigation() {
         navLinks.innerHTML = `
             <a href="/index.html">Home</a>
             <a href="/pages/feed.html">Feed</a>
+            <a href="/pages/people.html">People</a>
             <a href="/pages/messages.html">Messages</a>
             <a href="/pages/groups.html">Groups</a>
+            <a href="/pages/profile.html">Profile</a>
             <a href="#" onclick="logout()">Logout</a>
         `;
     } else {


### PR DESCRIPTION
## Summary
- show People and Profile tabs in navigation when logged in

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d78e562308322bdaf6154362ba60f