### PR TITLE
Fix group creation

### DIFF
--- a/frontend/js/groups.js
+++ b/frontend/js/groups.js
@@ -200,6 +200,7 @@ function setupCreateGroupModal() {
 
         const name = document.getElementById('group-name').value.trim();
         const description = document.getElementById('group-description').value.trim();
+        const token = localStorage.getItem('token');
 
         try {
             const response = await fetch(`${API_URL}/groups`, {


### PR DESCRIPTION
## Summary
- retrieve auth token when creating a group so request is authorized

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da4d9919c8322890982f2f03ee7e6