### PR TITLE
Fix groups page JS errors

### DIFF
--- a/frontend/js/groups.js
+++ b/frontend/js/groups.js
@@ -111,6 +111,9 @@ async function loadMyGroups() {
 
 function displayMyGroups(groups) {
     const myGroupsContainer = document.getElementById('my-groups');
+    if (!myGroupsContainer) {
+        return;
+    }
     myGroupsContainer.innerHTML = '';
 
     if (!groups || groups.length === 0) {
@@ -177,7 +180,7 @@ function displaySuggestedGroups(groups) {
                 <p>${group.membersCount} members</p>
             </div>
         `;
-        container.appendChild(div);
+        suggestedGroupsContainer.appendChild(groupElement);
     });
 }
 


### PR DESCRIPTION
## Summary
- avoid JS error when 'my-groups' container is missing
- fix suggested groups rendering

## Testing
- `mvn -q test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684da6164e6c83229296f61293e618af